### PR TITLE
Added options.remote for alternative remote repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Then, use it in your build system:
 ```javascript
   buildBranch({
     branch: 'gh-pages',
+    remote: 'origin',
     ignore: ['.git', 'www', 'node_modules'],
     folder: 'www',
     domain: 'example.com'
@@ -68,6 +69,12 @@ Type: `String`
 Default: 'gh-pages'
 
 The branch on wich to publish.
+
+##### options.remote
+Type: `String`
+Default: 'origin'
+
+The remote repository on wich to publish.
 
 ##### options.folder
 Type: `String`

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ function buildBranch(options, callback) {
   // Checking options
   options.folder = options.folder || 'www';
   options.branch = options.branch || 'gh-pages';
+  options.remote = options.remote || 'origin';
   options.ignore = options.ignore || [];
   options.ignore.push('.git', 'node_modules', options.folder);
   options.cname = options.cname || 'CNAME';
@@ -75,7 +76,7 @@ function buildBranch(options, callback) {
         }
 
         // Pushing commit
-        command = 'git push -f origin ' + options.branch + ';'
+        command = 'git push -f ' + options.remote + ' ' + options.branch + ';'
                 + ' git checkout ' + curBranch + ' ;'
                 + ' git checkout .';
 


### PR DESCRIPTION
Nobody guarantees the remote we would like to push to is called `origin`. It's a usual name, but not the only. I created an option `remote` for changing the remote repo name to push.