### PR TITLE
Update metapak/metapak-nfroidure, remove debug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-* text=auto
+*.md text eol=lf
+*.html text eol=lf
 *.js text eol=lf

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -15,9 +15,9 @@ Finally scroll down if you asking for a feature ;)
 -->
 
 I'm a gentledev i:
-[ ] fully read the README recently
-[ ] searched for existing issues
-[ ] checked i'm up to date with the latest version of the project
+- [ ] fully read the README recently
+- [ ] searched for existing issues
+- [ ] checked i'm up to date with the latest version of the project
 
 ### Expected behavior
 
@@ -56,4 +56,4 @@ If you think a feature need to be added, your suggestions
 
 ### Use cases
 
-[ ] I will do it
+- [ ] I will/have implement the feature

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -17,16 +17,16 @@ Fixes #
 <!-- Check the boxes with a `x` like so `[x]` -->
 
 ### Code quality
-[ ] I made some tests for my changes
-[ ] I added my name in the
+- [ ] I made some tests for my changes
+- [ ] I added my name in the
  [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
  field of the package.json file
 
 ### License
 To get your contribution merged, you must check the following.
 
-[ ] I read the project license in the LICENSE file
-[ ] I agree with publishing under this project license
+- [ ] I read the project license in the LICENSE file
+- [ ] I agree with publishing under this project license
 
 <!--
 
@@ -43,8 +43,8 @@ GitHub/NPM r/w access.
 
 -->
 ### Join
-[ ] I wish to join the core team
-[ ] I agree that with great powers comes responsibilities
-[ ] I'm a nice person
+- [ ] I wish to join the core team
+- [ ] I agree that with great powers comes responsibilities
+- [ ] I'm a nice person
 
 My NPM username:

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@
 > Publish a folder to the given build branch (like gh-pages).
 
 [![NPM version](https://badge.fury.io/js/buildbranch.svg)](https://npmjs.org/package/buildbranch)
-[![Build status](https://secure.travis-ci.org/nfroidure/buildbranch.svg)](https://travis-ci.org/nfroidure/buildbranch)
 [![Dependency Status](https://david-dm.org/nfroidure/buildbranch.svg)](https://david-dm.org/nfroidure/buildbranch)
 [![devDependency Status](https://david-dm.org/nfroidure/buildbranch/dev-status.svg)](https://david-dm.org/nfroidure/buildbranch#info=devDependencies)
 [![Coverage Status](https://coveralls.io/repos/nfroidure/buildbranch/badge.svg?branch=master)](https://coveralls.io/r/nfroidure/buildbranch?branch=master)
-[![Code Climate](https://codeclimate.com/github/nfroidure/buildbranch.svg)](https://codeclimate.com/github/nfroidure/buildbranch)
 [![Dependency Status](https://dependencyci.com/github/nfroidure/buildbranch/badge)](https://dependencyci.com/github/nfroidure/buildbranch)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "cli": "env NODE_ENV=${NODE_ENV:-cli}",
     "cz": "env NODE_ENV=${NODE_ENV:-cli} git cz",
     "lint": "eslint src/**.js",
-    "metapak": "metapak || echo 'Please `npm install --save-dev metapak`' && exit 0",
+    "metapak": "metapak",
     "postinstall": "npm run metapak; npm run metapak --silent",
-    "preversion": "npm t && npm run lint",
+    "preversion": "npm t && npm run lint && npm run metapak -s",
     "test": "exit 0",
     "version": "npm run changelog && git add CHANGELOG.md"
   },
@@ -49,19 +49,18 @@
     "github"
   ],
   "dependencies": {
-    "debug": "2.6.9",
     "rimraf": "^2.5.2"
   },
   "devDependencies": {
     "commitizen": "^2.9.6",
-    "conventional-changelog-cli": "^1.2.0",
+    "conventional-changelog-cli": "^1.3.5",
     "coveralls": "2.11.15",
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "3.16.0",
     "eslint-config-simplifield": "4.1.1",
     "istanbul": "0.4.5",
-    "metapak": "0.0.18",
-    "metapak-nfroidure": "^0.4.1",
+    "metapak": "1.0.3",
+    "metapak-nfroidure": "^1.0.2",
     "mocha": "3.2.0",
     "mocha-lcov-reporter": "1.3.0"
   },
@@ -72,15 +71,8 @@
   },
   "greenkeeper": {
     "ignore": [
-      "debug",
-      "eslint",
-      "eslint-config-simplifield",
-      "mocha",
-      "mocha-lcov-reporter",
       "commitizen",
       "cz-conventional-changelog",
-      "coveralls",
-      "istanbul",
       "conventional-changelog-cli"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "cz": "env NODE_ENV=${NODE_ENV:-cli} git cz",
     "lint": "eslint src/**.js",
     "metapak": "metapak",
-    "postinstall": "npm run metapak; npm run metapak --silent",
     "preversion": "npm t && npm run lint && npm run metapak -s",
     "test": "exit 0",
     "version": "npm run changelog && git add CHANGELOG.md"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "github"
   ],
   "dependencies": {
-    "debug": "2.6.1",
+    "debug": "2.6.9",
     "rimraf": "^2.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #15 

This update metapak and metapak-nfroidure. It should fix #15.

It also removes the `debug` dependency which wasn't used anyway, had a security vulnerability in the version that has been used and isn't added by newer versions of metapak-nfroidure anymore as far as I can see.

All other changes were introduced by metapak magic.

### Code quality
[-] I made some tests for my changes
[-] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file

### License
To get your contribution merged, you must check the following.

[X] I read the project license in the LICENSE file
[X] I agree with publishing under this project license
